### PR TITLE
Set prec field based on min value during introspection

### DIFF
--- a/src/fastcs_eiger/eiger_parameter.py
+++ b/src/fastcs_eiger/eiger_parameter.py
@@ -59,11 +59,8 @@ def key_to_attribute_name(key: str):
 def minimum_to_precision(value: float | None) -> int:
     if value is not None:
         value_as_str = str(value)
-        for separator in [".", "e"]:
-            if separator in value_as_str:
-                return (
-                    len(value_as_str.split(separator)[1])
-                    if separator == "."
-                    else abs(int(value_as_str.split(separator)[1]))
-                )
+        if "." in value_as_str:
+            return len(value_as_str.split(".")[1])
+        elif "e" in value_as_str:
+            return abs(int(value_as_str.split("e")[1]))
     return 2

--- a/src/fastcs_eiger/eiger_parameter.py
+++ b/src/fastcs_eiger/eiger_parameter.py
@@ -56,7 +56,7 @@ def key_to_attribute_name(key: str):
     return key.replace("/", "_")
 
 
-def minimum_to_precision(value: float | int | None) -> int:
+def minimum_to_precision(value: float | None) -> int:
     if value is not None:
         value_as_str = str(value)
         for separator in [".", "e"]:

--- a/src/fastcs_eiger/eiger_parameter.py
+++ b/src/fastcs_eiger/eiger_parameter.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 class EigerParameterResponse(BaseModel):
     access_mode: Literal["r", "w", "rw"]
     allowed_values: Any | None = None
+    min: float | int | None = None
     value: Any
     value_type: Literal[
         "float", "int", "bool", "uint", "string", "datetime", "State", "string[]"
@@ -38,7 +39,9 @@ class EigerParameter:
     def fastcs_datatype(self) -> DataType:
         match self.response.value_type:
             case "float":
-                return Float()
+                min = self.response.min
+                prec = len(str(min).split(".")[1]) if isinstance(min, float) else 2
+                return Float(prec=prec)
             case "int" | "uint":
                 return Int()
             case "bool":

--- a/src/fastcs_eiger/eiger_parameter.py
+++ b/src/fastcs_eiger/eiger_parameter.py
@@ -39,8 +39,7 @@ class EigerParameter:
     def fastcs_datatype(self) -> DataType:
         match self.response.value_type:
             case "float":
-                prec = float_to_precision(str(self.response.min))
-                return Float(prec=prec)
+                return Float(prec=minimum_to_precision(self.response.min))
             case "int" | "uint":
                 return Int()
             case "bool":
@@ -57,12 +56,14 @@ def key_to_attribute_name(key: str):
     return key.replace("/", "_")
 
 
-def float_to_precision(value: str) -> int:
-    for separator in [".", "e"]:
-        if separator in value:
-            return (
-                len(value.split(separator)[1])
-                if separator == "."
-                else abs(int(value.split(separator)[1]))
-            )
+def minimum_to_precision(value: float | int | None) -> int:
+    if value is not None:
+        value_as_str = str(value)
+        for separator in [".", "e"]:
+            if separator in value_as_str:
+                return (
+                    len(value_as_str.split(separator)[1])
+                    if separator == "."
+                    else abs(int(value_as_str.split(separator)[1]))
+                )
     return 2

--- a/src/fastcs_eiger/eiger_parameter.py
+++ b/src/fastcs_eiger/eiger_parameter.py
@@ -39,8 +39,7 @@ class EigerParameter:
     def fastcs_datatype(self) -> DataType:
         match self.response.value_type:
             case "float":
-                min = self.response.min
-                prec = len(str(min).split(".")[1]) if isinstance(min, float) else 2
+                prec = float_to_precision(str(self.response.min))
                 return Float(prec=prec)
             case "int" | "uint":
                 return Int()
@@ -56,3 +55,14 @@ EIGER_PARAMETER_MODES = EigerParameter.__annotations__["mode"].__args__
 
 def key_to_attribute_name(key: str):
     return key.replace("/", "_")
+
+
+def float_to_precision(value: str) -> int:
+    for separator in [".", "e"]:
+        if separator in value:
+            return (
+                len(value.split(separator)[1])
+                if separator == "."
+                else abs(int(value.split(separator)[1]))
+            )
+    return 2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,12 +60,5 @@ def mock_connection(mocker: MockerFixture):
     eiger_controller = EigerController("127.0.0.1", 80)
     connection = mocker.patch.object(eiger_controller, "connection")
     connection.get = mock.AsyncMock()
-    # Arbitrary values to satisfy pydantic model.
-    connection.get.return_value = {
-        "access_mode": "rw",
-        "allowed_values": None,
-        "value": "test_value",
-        "value_type": "string",
-    }
     connection.put = mock.AsyncMock()
     return eiger_controller, connection

--- a/tests/system/test_introspection.py
+++ b/tests/system/test_introspection.py
@@ -274,6 +274,9 @@ async def test_attribute_validation_accepts_valid_types(mock_connection, valid_t
         [123.123, 3],
         [0, 2],
         [0.0, 1],
+        [1e-5, 5],
+        [1e5, 1],
+        [None, 2],
     ],
 )
 async def test_if_min_value_provided_then_prec_set_correctly(

--- a/tests/system/test_introspection.py
+++ b/tests/system/test_introspection.py
@@ -263,7 +263,22 @@ async def test_attribute_validation_accepts_valid_types(mock_connection, valid_t
 
 
 @pytest.mark.asyncio
-async def test_if_min_value_provided_then_prec_set_correctly(mock_connection):
+@pytest.mark.parametrize(
+    "mock_min, expected_prec",
+    [
+        [0.0001, 4],
+        [0.001, 3],
+        [0.01, 2],
+        [0.1, 1],
+        [1, 2],  # Case where min is int.
+        [123.123, 3],
+        [0, 2],
+        [0.0, 1],
+    ],
+)
+async def test_if_min_value_provided_then_prec_set_correctly(
+    mock_min, expected_prec, mock_connection
+):
     eiger_controller, connection = mock_connection
 
     connection.get.side_effect = [
@@ -274,7 +289,7 @@ async def test_if_min_value_provided_then_prec_set_correctly(mock_connection):
             "allowed_values": None,
             "value": 1.0,
             "value_type": "float",
-            "min": 0.0001,  # Based on this field, prec should be set to 4.
+            "min": mock_min,
         },
         {
             "access_mode": "r",
@@ -294,4 +309,4 @@ async def test_if_min_value_provided_then_prec_set_correctly(mock_connection):
         "test_float_attr"
     )
 
-    assert test_float_attr.datatype == Float(prec=4)
+    assert test_float_attr.datatype == Float(prec=expected_prec)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -7,6 +7,15 @@ from fastcs_eiger.eiger_controller import EigerHandler
 @pytest.mark.asyncio
 async def test_eiger_controller_creates_subcontrollers(mock_connection):
     eiger_controller, connection = mock_connection
+
+    # Arbitrary HTTP response for pydantic model.
+    connection.get.return_value = {
+        "access_mode": "r",
+        "allowed_values": None,
+        "value": "test_value",
+        "value_type": "string",
+    }
+
     await eiger_controller.initialise()
     assert list(eiger_controller.get_sub_controllers().keys()) == [
         "Detector",


### PR DESCRIPTION
Fixes #63

Following #62, we are now be able to set the `prec` field of attributes by parsing their `min` value.