### PR TITLE
Update to work with FastCS 0.9.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
 description = "Eiger control system integration with FastCS"
 dependencies = [
     "aiohttp",
-    "fastcs @ git+https://github.com/epics-containers/fastcs.git@main",
+    "fastcs~=0.9.0",
     "numpy",
     "pillow",
     "typer",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
 description = "Eiger control system integration with FastCS"
 dependencies = [
     "aiohttp",
-    "fastcs~=0.8.0",
+    "fastcs @ git+https://github.com/epics-containers/fastcs.git@main",
     "numpy",
     "pillow",
     "typer",

--- a/src/fastcs_eiger/__main__.py
+++ b/src/fastcs_eiger/__main__.py
@@ -3,10 +3,10 @@ from typing import Optional
 
 import typer
 from fastcs.launch import FastCS
-from fastcs.transport.epics.options import (
+from fastcs.transport.epics.ca.options import (
+    EpicsCAOptions,
     EpicsGUIOptions,
     EpicsIOCOptions,
-    EpicsOptions,
 )
 
 from fastcs_eiger import __version__
@@ -55,13 +55,13 @@ def ioc(
 
     controller = EigerController(ip, port)
 
-    options = EpicsOptions(
+    options = EpicsCAOptions(
         ioc=EpicsIOCOptions(pv_prefix=pv_prefix),
         gui=EpicsGUIOptions(
             output_path=ui_path / "eiger.bob", title=f"Eiger - {pv_prefix}"
         ),
     )
-    launcher = FastCS(controller, options)
+    launcher = FastCS(controller, [options])
     launcher.create_docs()
     launcher.create_gui()
     launcher.run()

--- a/src/fastcs_eiger/__main__.py
+++ b/src/fastcs_eiger/__main__.py
@@ -56,7 +56,7 @@ def ioc(
     controller = EigerController(ip, port)
 
     options = EpicsCAOptions(
-        ioc=EpicsIOCOptions(pv_prefix=pv_prefix),
+        ca_ioc=EpicsIOCOptions(pv_prefix=pv_prefix),
         gui=EpicsGUIOptions(
             output_path=ui_path / "eiger.bob", title=f"Eiger - {pv_prefix}"
         ),

--- a/src/fastcs_eiger/eiger_controller.py
+++ b/src/fastcs_eiger/eiger_controller.py
@@ -362,7 +362,6 @@ class EigerSubsystemController(SubController):
                         parameter.fastcs_datatype,
                         handler=EIGER_HANDLERS[parameter.mode](parameter.uri),
                         group=group,
-                        # allowed_values=parameter.response.allowed_values,
                     )
         return attributes
 

--- a/src/fastcs_eiger/eiger_controller.py
+++ b/src/fastcs_eiger/eiger_controller.py
@@ -5,7 +5,7 @@ from io import BytesIO
 from typing import Any, Literal
 
 import numpy as np
-from fastcs.attributes import Attribute, AttrR, AttrRW, AttrW, Handler
+from fastcs.attributes import AttrHandlerRW, Attribute, AttrR, AttrRW, AttrW
 from fastcs.controller import BaseController, Controller, SubController
 from fastcs.datatypes import Bool, Float, String
 from fastcs.wrappers import command, scan
@@ -62,7 +62,7 @@ def detector_command(fn) -> Any:
 
 
 @dataclass
-class EigerHandler:
+class EigerHandler(AttrHandlerRW):
     """
     Handler for FastCS Attribute Creation
 
@@ -72,6 +72,18 @@ class EigerHandler:
 
     uri: str
     update_period: float | None = 0.2
+    _controller: "EigerSubsystemController | None" = None
+
+    async def initialise(self, controller: BaseController):
+        assert isinstance(controller, EigerSubsystemController)
+        self._controller = controller
+
+    @property
+    def controller(self) -> "EigerSubsystemController":
+        if self._controller is None:
+            raise RuntimeError("Handler not initialised")
+
+        return self._controller
 
     def _handle_params_to_update(self, parameters: list[str]):
         update_now = []
@@ -89,20 +101,18 @@ class EigerHandler:
                     update_later.append(parameter)
         return update_now, update_later
 
-    async def put(
-        self, controller: "EigerSubsystemController", attr: AttrW, value: Any
-    ) -> None:
-        parameters_to_update = await controller.connection.put(self.uri, value)
+    async def put(self, attr: AttrW, value: Any) -> None:
+        parameters_to_update = await self.controller.connection.put(self.uri, value)
         update_now, update_later = self._handle_params_to_update(parameters_to_update)
-        await controller.update_now(update_now)
+        await self.controller.update_now(update_now)
         print(
             f"Queueing updates for parameters after setting {self.uri}: {update_later}"
         )
-        await controller.queue_update(update_later)
+        await self.controller.queue_update(update_later)
 
-    async def update(self, controller: "EigerSubsystemController", attr: AttrR) -> None:
+    async def update(self, attr: AttrR) -> None:
         try:
-            response = await controller.connection.get(self.uri)
+            response = await self.controller.connection.get(self.uri)
             value = response["value"]
             if isinstance(value, list) and all(
                 isinstance(s, str) for s in value
@@ -118,24 +128,22 @@ class EigerConfigHandler(EigerHandler):
 
     first_poll_complete: bool = False
 
-    async def update(self, controller: "EigerSubsystemController", attr: AttrR) -> None:
+    async def update(self, attr: AttrR) -> None:
         # Only poll once on startup
         if not self.first_poll_complete:
-            await super().update(controller, attr)
+            await super().update(attr)
             if isinstance(attr, AttrRW):
                 # Sync readback value to demand
                 await attr.update_display_without_process(attr.get())
 
             self.first_poll_complete = True
 
-    async def config_update(
-        self, controller: "EigerSubsystemController", attr: AttrR
-    ) -> None:
-        await super().update(controller, attr)
+    async def config_update(self, attr: AttrR) -> None:
+        await super().update(attr)
 
 
 @dataclass
-class LogicHandler(Handler):
+class LogicHandler(AttrHandlerRW):
     """
     Handler for FastCS Attribute Creation
 
@@ -143,7 +151,20 @@ class LogicHandler(Handler):
     Used for dynamically created attributes that are added for additional logic
     """
 
-    async def put(self, controller: BaseController, attr: AttrW, value: Any) -> None:
+    _controller: BaseController | None = None
+
+    async def initialise(self, controller: BaseController):
+        assert isinstance(controller, BaseController)
+        self._controller = controller
+
+    @property
+    def controller(self) -> BaseController:
+        if self._controller is None:
+            raise RuntimeError("Handler not initialised")
+
+        return self._controller
+
+    async def put(self, attr: AttrW, value: Any) -> None:
         assert isinstance(attr, AttrR)  # AttrW does not implement set
         await attr.set(value)
 
@@ -341,7 +362,7 @@ class EigerSubsystemController(SubController):
                         parameter.fastcs_datatype,
                         handler=EIGER_HANDLERS[parameter.mode](parameter.uri),
                         group=group,
-                        allowed_values=parameter.response.allowed_values,
+                        # allowed_values=parameter.response.allowed_values,
                     )
         return attributes
 
@@ -379,7 +400,7 @@ class EigerSubsystemController(SubController):
             attr_name = key_to_attribute_name(parameter)
             match self.attributes.get(attr_name, None):
                 case AttrR(updater=EigerConfigHandler() as updater) as attr:
-                    coros.append(updater.config_update(self, attr))
+                    coros.append(updater.config_update(attr))
                 case _ as attr:
                     if parameter not in IGNORED_KEYS:
                         print(

--- a/tests/system/test_introspection.py
+++ b/tests/system/test_introspection.py
@@ -50,7 +50,6 @@ def _serialise_parameter(parameter: EigerParameter) -> dict:
 async def test_attribute_creation(sim_eiger_controller: EigerController):
     controller = sim_eiger_controller
     await controller.initialise()
-    await controller.attribute_initialise()
     serialised_parameters: dict[str, dict[str, Any]] = {}
     subsystem_parameters = {}
     for subcontroller in controller.get_subsystem_controllers():
@@ -103,7 +102,6 @@ async def test_attribute_creation(sim_eiger_controller: EigerController):
 async def test_controller_groups_and_parameters(sim_eiger_controller: EigerController):
     controller = sim_eiger_controller
     await controller.initialise()
-    await controller.attribute_initialise()
 
     for subsystem in MISSING_KEYS:
         subcontroller = controller.get_sub_controllers()[subsystem.title()]

--- a/tests/system/test_introspection.py
+++ b/tests/system/test_introspection.py
@@ -156,6 +156,7 @@ async def test_threshold_mode_api_consistency_handled(
 
     await sender.put(attr, "enabled")
     queue_update_spy.assert_called_with(["threshold/difference/mode"])
+    await controller.update()
     await detector_controller.connection.close()
 
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1,7 +1,7 @@
 import pytest
 from pytest_mock import MockerFixture
 
-from fastcs_eiger.eiger_controller import EigerHandler
+from fastcs_eiger.eiger_controller import EigerHandler, EigerSubsystemController
 
 
 @pytest.mark.asyncio
@@ -36,28 +36,38 @@ async def test_eiger_handler_update_updates_value(mocker: MockerFixture):
     dummy_uri = "subsystem/api/1.8.0/dummy_mode/dummy_uri"
     updater = EigerHandler(dummy_uri)
     controller = mocker.AsyncMock()
+    mock_connection = mocker.AsyncMock()
+    mock_connection.get.return_value = {"value": 5}
+    controller = EigerSubsystemController(mock_connection, mocker.MagicMock())
     attr = mocker.Mock()
 
-    controller.connection.get.return_value = {"value": 5}
-
-    await updater.update(controller, attr)
+    await updater.initialise(controller)
+    await updater.update(attr)
     attr.set.assert_called_once_with(5)
 
 
 @pytest.mark.asyncio
 async def test_eiger_handler_put(mocker: MockerFixture):
     dummy_uri = "subsystem/api/1.8.0/dummy_mode/dummy_uri"
-    controller = mocker.AsyncMock()
-    await EigerHandler(dummy_uri).put(controller, mocker.Mock(), 0.1)
-    controller.connection.put.assert_awaited_once_with(dummy_uri, 0.1)
+    mock_connection = mocker.AsyncMock()
+    controller = EigerSubsystemController(mock_connection, mocker.AsyncMock())
+    controller.queue_update = mocker.AsyncMock()
+
+    handler = EigerHandler(dummy_uri)
+    await handler.initialise(controller)
+    await handler.put(mocker.Mock(), 0.1)
+
+    mock_connection.put.assert_awaited_once_with(dummy_uri, 0.1)
     controller.queue_update.assert_awaited_once_with(
-        list(controller.connection.put.return_value)
+        list(mock_connection.put.return_value)
     )
 
     # if controller.connection.put returns [],
     # still queue_update for the handled uri
-    controller.connection.put.return_value = []
+    mock_connection.put.return_value = []
     no_updated_params_uri = "susbsystem/api/1.8.0/dummy_mode/no_updated_params"
-    await EigerHandler(no_updated_params_uri).put(controller, mocker.Mock(), 0.1)
-    controller.connection.put.assert_awaited_with(no_updated_params_uri, 0.1)
+    handler = EigerHandler(no_updated_params_uri)
+    await handler.initialise(controller)
+    await handler.put(mocker.Mock(), 0.1)
+    mock_connection.put.assert_awaited_with(no_updated_params_uri, 0.1)
     controller.queue_update.assert_awaited_with(["no_updated_params"])


### PR DESCRIPTION
This PR updates fastcs-eiger to work with `FastCS 0.9.0`