### PR TITLE
chore: minimal changes to get pva transport working

### DIFF
--- a/src/fastcs_eiger/controllers/eiger_controller.py
+++ b/src/fastcs_eiger/controllers/eiger_controller.py
@@ -38,7 +38,7 @@ class EigerController(Controller):
     # Internal Attributes
     stale_parameters = AttrR(Bool())
     arm_timeout = AttrRW(
-        Int(min=1),
+        Int(min=0),
         initial_value=3,
         description="Timeout for arm command",
         group=COMMAND_GROUP,

--- a/src/fastcs_eiger/controllers/eiger_subsystem_controller.py
+++ b/src/fastcs_eiger/controllers/eiger_subsystem_controller.py
@@ -39,6 +39,7 @@ IGNORED_KEYS = [
     # TODO: Is it a bad idea to include these?
     "test_image_mode",
     "test_image_value",
+    "description",  # Shadows description field on controllers
 ]
 
 # Parameters that are in the API but missing from keys

--- a/src/fastcs_eiger/controllers/odin/eiger_odin_controller.py
+++ b/src/fastcs_eiger/controllers/odin/eiger_odin_controller.py
@@ -24,7 +24,7 @@ class EigerOdinController(EigerController):
     """Eiger controller with Odin sub controller"""
 
     start_writing_timeout = AttrRW(
-        Int(min=1),
+        Int(min=0),
         initial_value=5,
         description="Timeout for start writing command",
         group=COMMAND_GROUP,

--- a/src/fastcs_eiger/fastcs-eiger-odin.yaml
+++ b/src/fastcs_eiger/fastcs-eiger-odin.yaml
@@ -10,7 +10,7 @@ controllers:
       port: 8888
     api_version: "1.8.0"
 transport:
-  - epicsca: {}
+  - epicspva: {}
     gui:
       title: "Eiger - EIGER"
       output_dir: ./opi/

--- a/src/fastcs_eiger/fastcs-eiger.yaml
+++ b/src/fastcs_eiger/fastcs-eiger.yaml
@@ -7,7 +7,7 @@ controllers:
       port: 8081
     api_version: "1.8.0"
 transport:
-  - epicsca: {}
+  - epicspva: {}
     gui:
       title: "Eiger - EIGER"
       output_dir: ./opi/

--- a/tests/system/parameters.json
+++ b/tests/system/parameters.json
@@ -215,15 +215,6 @@
                 "value_type": "string"
             }
         },
-        "description": {
-            "subsystem": "detector",
-            "mode": "config",
-            "key": "description",
-            "response": {
-                "access_mode": "r",
-                "value_type": "string"
-            }
-        },
         "detector_distance": {
             "subsystem": "detector",
             "mode": "config",

--- a/tests/system/test_eiger_introspection.py
+++ b/tests/system/test_eiger_introspection.py
@@ -77,7 +77,7 @@ async def test_attribute_creation(sim_eiger):
     detector_attributes = EigerDetectorController._create_attributes(
         subsystem_parameters["detector"]
     )
-    assert len(detector_attributes) == 76
+    assert len(detector_attributes) == 75
     monitor_attributes = EigerMonitorController._create_attributes(
         subsystem_parameters["monitor"]
     )


### PR DESCRIPTION
This is related this ophyd-async issue, which requires the PVA transport on fastcs-eiger/odin.

This PR makes the minimal changes required to allow the IOCs to start up, and is built on top of #99.